### PR TITLE
feat: adds flexible toast alignment options

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -8,11 +8,13 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var toastAlignment: Alignment = .top
+    
     var body: some View {
       NavigationStack {
-        ToastyScreen()
+        ToastyScreen(toastAlignment: $toastAlignment)
       }
-      .toastable(alignment: .top)
+      .toastable(alignment: toastAlignment)
     }
 }
 

--- a/Example/Example/ToastyScreen.swift
+++ b/Example/Example/ToastyScreen.swift
@@ -10,9 +10,7 @@ import SwiftUI
 
 struct ToastyScreen: View {
   @Toast private var toast
-  
-  // Custom configuration for demonstration
-  private let customConfig = ToastConfiguration()
+  @Binding var toastAlignment: Alignment
   
   var body: some View {
     VStack(spacing: 20) {
@@ -20,7 +18,36 @@ struct ToastyScreen: View {
         .font(.title2)
         .fontWeight(.bold)
       
+      // Alignment Picker
+      VStack(spacing: 10) {
+        Text("Toast Position")
+          .font(.headline)
+        
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3), spacing: 8) {
+          alignmentButton(.topLeading, "↖️ Top Leading")
+          alignmentButton(.top, "⬆️ Top")
+          alignmentButton(.topTrailing, "↗️ Top Trailing")
+          
+          alignmentButton(.leading, "⬅️ Leading")
+          alignmentButton(.center, "🎯 Center")
+          alignmentButton(.trailing, "➡️ Trailing")
+          
+          alignmentButton(.bottomLeading, "↙️ Bottom Leading")
+          alignmentButton(.bottom, "⬇️ Bottom")
+          alignmentButton(.bottomTrailing, "↘️ Bottom Trailing")
+        }
+      }
+      .padding()
+      .background(Color.gray.opacity(0.1))
+      .cornerRadius(10)
+      
+      Divider()
+      
       VStack(spacing: 15) {
+        Text("Current Position: \(alignmentName(toastAlignment))")
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+        
         Button("Show Info Toast") {
           toast.show(message: "This is an informational message!", type: .info, duration: 3.0)
         }
@@ -46,11 +73,6 @@ struct ToastyScreen: View {
         }
         .buttonStyle(.bordered)
         
-        Button("Quick Toast (1s)") {
-          toast.show(message: "Quick message!", type: .success, duration: 1.0)
-        }
-        .buttonStyle(.bordered)
-        
         if toast.isShowingToast {
           Button("Dismiss Current Toast") {
             toast.dismiss()
@@ -69,5 +91,36 @@ struct ToastyScreen: View {
     .padding()
     .navigationTitle("Toast Demo")
     .navigationBarTitleDisplayMode(.inline)
+  }
+  
+  private func alignmentButton(_ alignment: Alignment, _ title: String) -> some View {
+    Button(title) {
+      toastAlignment = alignment
+    }
+    .font(.caption)
+    .foregroundColor(toastAlignment == alignment ? .white : .primary)
+    .padding(.vertical, 8)
+    .padding(.horizontal, 4)
+    .background(toastAlignment == alignment ? Color.accentColor : Color.clear)
+    .cornerRadius(6)
+    .overlay(
+      RoundedRectangle(cornerRadius: 6)
+        .stroke(Color.accentColor, lineWidth: toastAlignment == alignment ? 0 : 1)
+    )
+  }
+  
+  private func alignmentName(_ alignment: Alignment) -> String {
+    switch alignment {
+    case .topLeading: return "Top Leading"
+    case .top: return "Top"
+    case .topTrailing: return "Top Trailing"
+    case .leading: return "Leading"
+    case .center: return "Center"
+    case .trailing: return "Trailing"
+    case .bottomLeading: return "Bottom Leading"
+    case .bottom: return "Bottom"
+    case .bottomTrailing: return "Bottom Trailing"
+    default: return "Unknown"
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - 👆 Tap to dismiss
 - ♿️ Enhanced accessibility support with VoiceOver announcements
 - 📱 Safe area aware
-- 🎭 Flexible positioning (top, bottom)
+- 🎭 Flexible positioning (top, bottom, center, leading, trailing with variants)
 - 🛡️ Race condition protection for rapid toast calls
 - ✅ Input validation for empty messages and invalid durations
 - 🎨 Customizable appearance through configuration
@@ -120,8 +120,23 @@ struct ContentView: View {
 Adjust toast position using the alignment parameter:
 
 ```swift
+// Basic positions
 ContentView()
-    .toastable(alignment: .bottom) // Show toasts at the bottom
+    .toastable(alignment: .top)    // Top center
+    .toastable(alignment: .bottom) // Bottom center
+    .toastable(alignment: .center) // Screen center
+
+// Corner positions  
+ContentView()
+    .toastable(alignment: .topLeading)    // Top left
+    .toastable(alignment: .topTrailing)   // Top right
+    .toastable(alignment: .bottomLeading) // Bottom left
+    .toastable(alignment: .bottomTrailing)// Bottom right
+
+// Side positions
+ContentView()
+    .toastable(alignment: .leading)  // Left center
+    .toastable(alignment: .trailing) // Right center
 ```
 
 #### Appearance

--- a/Tests/ToastyTests/ToastyTests.swift
+++ b/Tests/ToastyTests/ToastyTests.swift
@@ -110,4 +110,31 @@ struct ToastyTests {
         #expect(manager.currentToast?.message == "Second")
         #expect(firstToastId != secondToastId)
     }
+    
+    @Test func toastPresenterModifierAlignment() async throws {
+        // Test that all alignment cases are handled without crashing
+        let alignments: [Alignment] = [
+            .top, .topLeading, .topTrailing,
+            .center, .leading, .trailing,
+            .bottom, .bottomLeading, .bottomTrailing
+        ]
+        
+        for alignment in alignments {
+            let modifier = ToastPresenterModifier(toastManager: ToastManager(), alignment: alignment)
+            
+            // Test that transition calculation doesn't crash
+            let transition = modifier.toastTransition(for: alignment)
+            // Just verify we can call the method without crashing
+            _ = transition
+            
+            // Test that offset calculation doesn't crash
+            let safeArea = EdgeInsets(top: 44, leading: 0, bottom: 34, trailing: 0)
+            let verticalOffset = modifier.calculateVerticalOffset(for: alignment, in: safeArea)
+            let horizontalOffset = modifier.calculateHorizontalOffset(for: alignment)
+            
+            // Verify offsets are reasonable
+            #expect(abs(verticalOffset) <= 100) // Should be reasonable offset
+            #expect(abs(horizontalOffset) <= 100) // Should be reasonable offset
+        }
+    }
 }


### PR DESCRIPTION
Enables users to position toasts in nine different locations (top, center, bottom, leading, trailing and their combinations).

Updates the toast presentation logic to handle various alignment options and transitions accordingly.

Refactors the example app to include a toast position picker for demonstrating the new alignment functionality.